### PR TITLE
Fix name inconsistency between read and write of setup config value "ShowReplayLogo"

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,9 @@
 VDR Plugin 'graphlcd' Revision History
 -------------------------------------
 
+2021-01-17
+- Fix name inconsistency between read and write of setup config value "ShowReplayLogo"
+
 2018-11-10: Version 1.0.1
 - Improved "trim" function which doesn't cause negative size_type values
 

--- a/menu.c
+++ b/menu.c
@@ -87,7 +87,7 @@ void cGraphLCDMenuSetup::Store()
 	SetupStore("ShowVolume",  GraphLCDSetup.ShowVolume = newGraphLCDSetup.ShowVolume);
 	SetupStore("ShowNotRecording", GraphLCDSetup.ShowNotRecording = newGraphLCDSetup.ShowNotRecording);
 	SetupStore("IdentifyReplayType", GraphLCDSetup.IdentifyReplayType = newGraphLCDSetup.IdentifyReplayType);
-	SetupStore("ReplayLogo", GraphLCDSetup.ShowReplayLogo = newGraphLCDSetup.ShowReplayLogo);
+	SetupStore("ShowReplayLogo", GraphLCDSetup.ShowReplayLogo = newGraphLCDSetup.ShowReplayLogo);
 	SetupStore("ModifyReplayString", GraphLCDSetup.ModifyReplayString = newGraphLCDSetup.ModifyReplayString);
 	SetupStore("ScrollMode", GraphLCDSetup.ScrollMode = newGraphLCDSetup.ScrollMode);
 	SetupStore("ScrollSpeed", GraphLCDSetup.ScrollSpeed = newGraphLCDSetup.ScrollSpeed);


### PR DESCRIPTION
After very wondering, why setting "ShowReplayLogo" stays not persistent I found a long outstanding inconsistency. SetupRead uses "ShowReplayLogo" while SetupWrite uses "ReplayLogo".

Before (inconsistent):

```
menu.c:	SetupStore("ReplayLogo", GraphLCDSetup.ShowReplayLogo = newGraphLCDSetup.ShowReplayLogo);
plugin.c:    else if (!strcasecmp(Name, "ShowReplayLogo")) GraphLCDSetup.ShowReplayLogo = atoi(Value);
```

After (aligned):
```
menu.c:	SetupStore("ShowReplayLogo", GraphLCDSetup.ShowReplayLogo = newGraphLCDSetup.ShowReplayLogo);
plugin.c:    else if (!strcasecmp(Name, "ShowReplayLogo")) GraphLCDSetup.ShowReplayLogo = atoi(Value);
```