### PR TITLE
fix deadlock in case of deleting a channel

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,7 @@
 VDR Plugin 'graphlcd' Revision History
 -------------------------------------
+2021-01-24
+- [pbiering] fix deadlock for vdr >= 2.4.4 (at least found here) in case of deleting a channel
 
 2021-01-17
 - Fix name inconsistency between read and write of setup config value "ShowReplayLogo"

--- a/state.c
+++ b/state.c
@@ -674,7 +674,9 @@ void cGraphLCDState::UpdateChannelInfo(void)
       mutex.Unlock();
     }
 
+#if APIVERSNUM < 20404
     mutex.Lock();
+#endif
 #if APIVERSNUM < 20301
     cChannel * ch = Channels.GetByNumber(mChannel.number);
 #else
@@ -710,7 +712,9 @@ void cGraphLCDState::UpdateChannelInfo(void)
         mChannel.isRadio = false;
     }
 
+#if APIVERSNUM < 20404
     mutex.Unlock();
+#endif
 }
 
 void cGraphLCDState::UpdateEventInfo(void)


### PR DESCRIPTION
at least on vdr 2.4.4 a deadlock was found once a channel would be deleted, OSD freezes.
After removing the mutex.lock it's working as expected.
Potentially also applicable to older versions.