### PR TITLE
Fix thread stop

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,7 @@
 VDR Plugin 'graphlcd' Revision History
 -------------------------------------
+2021-02-15: Version 1.0.5
+- [pbiering] move thread cancel in new introduced Stop() function (hint by VDR maintainer)
 
 2021-02-08: Version 1.0.4
 - [pbiering] add support for new feature: NumRecordings and ListRecordings

--- a/display.c
+++ b/display.c
@@ -31,7 +31,7 @@
 #include <vdr/remote.h>
 
 cGraphLCDDisplay::cGraphLCDDisplay()
-:   cThread("glcd_display"),
+:   cThread("graphlcd_display"),
     mLcd(NULL),
     mScreen(NULL),
     mSkin(NULL),
@@ -60,17 +60,14 @@ cGraphLCDDisplay::cGraphLCDDisplay()
 
 cGraphLCDDisplay::~cGraphLCDDisplay()
 {
+    Cancel(3);
+
     delete mSkin;
     delete mSkinConfig;
     delete mScreen;
     delete mGraphLCDState;
 
     delete mService;
-}
-
-void cGraphLCDDisplay::Stop (void)
-{
-    Cancel(3);
 }
 
 bool cGraphLCDDisplay::Initialise(GLCD::cDriver * Lcd, const std::string & CfgPath, const std::string & SkinsPath, const std::string & SkinName)

--- a/display.c
+++ b/display.c
@@ -395,7 +395,7 @@ void cGraphLCDDisplay::Action(void)
                     }
                 }
 #endif
-                cCondWait::SleepMs(101); // TODO: causes crash on stop
+                cCondWait::SleepMs(101);
             }
         }
         else

--- a/display.c
+++ b/display.c
@@ -60,14 +60,17 @@ cGraphLCDDisplay::cGraphLCDDisplay()
 
 cGraphLCDDisplay::~cGraphLCDDisplay()
 {
-    Cancel(3);
-
     delete mSkin;
     delete mSkinConfig;
     delete mScreen;
     delete mGraphLCDState;
 
     delete mService;
+}
+
+void cGraphLCDDisplay::Stop (void)
+{
+    Cancel(3);
 }
 
 bool cGraphLCDDisplay::Initialise(GLCD::cDriver * Lcd, const std::string & CfgPath, const std::string & SkinsPath, const std::string & SkinName)

--- a/display.c
+++ b/display.c
@@ -395,7 +395,7 @@ void cGraphLCDDisplay::Action(void)
                     }
                 }
 #endif
-                cCondWait::SleepMs(101);
+                cCondWait::SleepMs(100);
             }
         }
         else

--- a/display.c
+++ b/display.c
@@ -398,7 +398,7 @@ void cGraphLCDDisplay::Action(void)
                     }
                 }
 #endif
-                cCondWait::SleepMs(100);
+                cCondWait::SleepMs(101); // TODO: causes crash on stop
             }
         }
         else

--- a/display.h
+++ b/display.h
@@ -56,6 +56,7 @@ public:
     ~cGraphLCDDisplay(void);
 
     bool Initialise(GLCD::cDriver * Lcd, const std::string & CfgPath, const std::string & SkinsPath, const std::string & SkinName);
+    void Stop(void);
     void Tick();
     void Update();
     void Clear();

--- a/display.h
+++ b/display.h
@@ -56,7 +56,6 @@ public:
     ~cGraphLCDDisplay(void);
 
     bool Initialise(GLCD::cDriver * Lcd, const std::string & CfgPath, const std::string & SkinsPath, const std::string & SkinName);
-    void Stop(void);
     void Tick();
     void Update();
     void Clear();

--- a/plugin.c
+++ b/plugin.c
@@ -93,6 +93,7 @@ public:
     virtual bool ProcessArgs(int argc, char * argv[]);
     virtual bool Initialize();
     virtual bool Start();
+    virtual void Stop(void);
     virtual void Housekeeping();
     virtual const char **SVDRPHelpPages(void);
     virtual cString SVDRPCommand(const char *Command, const char *Option, int &ReplyCode);
@@ -120,10 +121,16 @@ cPluginGraphLCD::cPluginGraphLCD()
 
 cPluginGraphLCD::~cPluginGraphLCD()
 {
-    for (unsigned int index = 0; index < GRAPHLCD_MAX_DISPLAYS; index++)
-        DisconnectDisplay(index);
     mExtData->ReleaseExtData();
     mExtData = NULL;
+}
+
+void cPluginGraphLCD::Stop(void)
+{
+    for (unsigned int index = 0; index < GRAPHLCD_MAX_DISPLAYS; index++) {
+        dsyslog("graphlcd plugin: DisconnectDisplay %d", index);
+        DisconnectDisplay(index);
+    };
 }
 
 const char * cPluginGraphLCD::CommandLineHelp()

--- a/plugin.c
+++ b/plugin.c
@@ -39,7 +39,7 @@
 
 
 static const char * kPluginName = "graphlcd";
-static const char *VERSION        = "1.0.4";
+static const char *VERSION        = "1.0.5";
 static const char *DESCRIPTION    = trNOOP("Output to graphic LCD");
 static const char *MAINMENUENTRY  = NULL;
 

--- a/plugin.c
+++ b/plugin.c
@@ -121,8 +121,6 @@ cPluginGraphLCD::cPluginGraphLCD()
 
 cPluginGraphLCD::~cPluginGraphLCD()
 {
-    mExtData->ReleaseExtData();
-    mExtData = NULL;
 }
 
 void cPluginGraphLCD::Stop(void)
@@ -131,6 +129,9 @@ void cPluginGraphLCD::Stop(void)
         dsyslog("graphlcd plugin: DisconnectDisplay %d", index);
         DisconnectDisplay(index);
     };
+
+    mExtData->ReleaseExtData();
+    mExtData = NULL;
 }
 
 const char * cPluginGraphLCD::CommandLineHelp()


### PR DESCRIPTION
Fix thread stop (after receiving hint from VDR maintainer) by moving code from class destructor into Stop() function - this avoids crashes on VDR shutdown